### PR TITLE
Unbundle libpg_query

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,19 +4,25 @@ project(
     default_options: ['buildtype=release', 'prefix=/usr'],
 )
 
+cc = meson.get_compiler('c')
+libpg_query_sys = cc.find_library('pg_query', has_headers: 'pg_query.h', required: false)
+
+if not libpg_query_sys.found()
+    libpg_query = custom_target(
+        'libpg_query',
+        input: 'libpg_query/Makefile',
+        output: 'libpg_query.a',
+        command: ['script.sh', meson.current_build_dir(), meson.current_source_dir()],
+        build_always: true,
+        install: false,
+    )
+endif
+
 dependencies = [
     dependency('glib-2.0'),
     dependency('gobject-2.0'),
+    libpg_query_sys
 ]
-
-libpg_query = custom_target(
-    'libpg_query',
-    input: 'libpg_query/Makefile',
-    output: 'libpg_query.a',
-    command: ['script.sh', meson.current_build_dir(), meson.current_source_dir()],
-    build_always: true,
-    install: false,
-)
 
 # foobar_dep = declare_dependency (sources: lib_target)
 
@@ -28,21 +34,26 @@ vapi_dir = meson.current_source_dir() / 'vapi'
 add_project_arguments(['--vapidir', vapi_dir], language: 'vala')
 add_project_arguments(['--pkg', 'libpg_query'], language: 'vala')
 
-# cc = meson.get_compiler('c')
-# lib_path = meson.current_source_dir() / 'libpg_query'
-# libpg_query = cc.find_library('pg_query', required: true, dirs: lib_path)
+if libpg_query_sys.found()
+    pgquery_vala = library('pgquery-vala', sources,
+        dependencies: dependencies,
+        include_directories: include_directories('libpg_query'),
+        install: true,
+        install_dir: [true, true, true]
+    )
+else
+    pgquery_vala = library('pgquery-vala', sources,
+        dependencies: dependencies,
+        include_directories: include_directories('libpg_query'),
+        install: true,
+		link_with: libpg_query,
+        install_dir: [true, true, true]
+    )
 
-pgquery_vala = library('pgquery-vala', sources,
-    dependencies: dependencies,
-    include_directories: include_directories('libpg_query'),
-    install: true,
-    link_with: libpg_query,
-    install_dir: [true, true, true]
-)
-
-install_headers(
-    'libpg_query/pg_query.h',
-)
+    install_headers(
+        'libpg_query/pg_query.h',
+    )
+endif
 
 # pgquery_vala_dep = declare_dependency(
 #     include_directories: include_directories('libpg_query/include'),


### PR DESCRIPTION
Hello,

I recently [packaged psequel for Gentoo](https://github.com/gentoo/guru/commit/3603f1f49eeda9b2d0b33e62d91128dbeb7d02b1) and thus included a [package for pg_query_vala](https://github.com/gentoo/guru/commit/f7b91103a5d41d31e4305c1d70d92c9b41aae4dd). I also [packaged libpg_query](https://github.com/gentoo/guru/commit/4435babc4209a9564bd88c180e4b0b0cfdc8bdc3) separately from pg_query_vala (version 5.1.0).

Presently, pg_query_vala installs the libpg_query `.a` and `.so` files.
In the case of Gentoo (and I'm assuming other distros) this prevented pg_query_vala from being installed at the same time as the libpg_query package due to these file conflicts.
This PR unbundles libpg_query from this project and now instead depends on it being installed separately.

I'm applying this patch on the Gentoo package for pg_query_vala and it works fine, though please let me know if it can be improved :)